### PR TITLE
[cpp] Various post-merge fixes

### DIFF
--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -1319,8 +1319,7 @@ impl CppInterfaceGenerator<'_> {
         {
             if matches!(is_drop, SpecialMethod::Allocate) {
                 res.result.push_str("Owned");
-            }
-            if let Some(ty) = &func.result {
+            } else if let Some(ty) = &func.result {
                 res.result.push_str(
                     &(self.type_name(ty, outer_namespace, Flavor::Result(abi_variant))
                         + if matches!(is_drop, SpecialMethod::ResourceRep) {

--- a/crates/cpp/src/lib.rs
+++ b/crates/cpp/src/lib.rs
@@ -3367,12 +3367,12 @@ impl<'a, 'b> Bindgen for FunctionBindgen<'a, 'b> {
                 self.push_str(&format!("for (unsigned i = 0; i<{vec}.size(); ++i) {{\n",));
                 self.push_str(&format!(
                     "{ptr_type} base = {target} + i * {size_str};
-                     {typename}& iter_elem = {vec}[i];\n"
+                     {typename}& IterElem = {vec}[i];\n"
                 ));
                 self.push_str(&body.0);
                 self.push_str("\n}\n}\n");
             }
-            abi::Instruction::IterElem { .. } => results.push("iter_elem".to_string()),
+            abi::Instruction::IterElem { .. } => results.push("IterElem".to_string()),
             abi::Instruction::IterBasePointer => results.push("base".to_string()),
             abi::Instruction::RecordLower { record, .. } => {
                 let op = &operands[0];

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -202,12 +202,12 @@ impl<'i> InterfaceGenerator<'i> {
             let resource_name = self.resolve.types[resource].name.as_ref().unwrap();
             if self.gen.opts.symmetric {
                 let resource_type = resource_name.to_pascal_case();
-                let resource_lowercase = resource_name.to_lower_camel_case();
+                let resource_snake = resource_name.to_snake_case();
                 uwriteln!(
                     self.src,
                     r#"#[doc(hidden)]
             #[allow(non_snake_case)]
-            pub unsafe fn _export_drop_{resource_lowercase}_cabi<T: {trait_name}>(arg0: usize) {{
+            pub unsafe fn _export_drop_{resource_snake}_cabi<T: {trait_name}>(arg0: usize) {{
                 #[cfg(target_arch = "wasm32")]
                 _rt::run_ctors_once();
                 {resource_type}::dtor::<T>(arg0 as *mut u8);
@@ -364,19 +364,19 @@ macro_rules! {macro_name} {{
                 }
             };
             let camel = name.to_upper_camel_case();
+            let snake = name.to_snake_case();
             if self.gen.opts.symmetric {
                 let dtor_symbol = make_external_symbol(
                     &module,
                     &(String::from("[resource-drop]") + &name),
                     AbiVariant::GuestImport,
                 );
-                let resource_lowercase = name.to_lower_camel_case();
                 uwriteln!(
                     self.src,
                     r#"    #[cfg_attr(not(target_arch = "wasm32"), no_mangle)]
     #[allow(non_snake_case)]
     unsafe extern "C" fn {dtor_symbol}(arg0: usize) {{
-      $($path_to_types)*::_export_drop_{resource_lowercase}_cabi::<<$ty as $($path_to_types)*::Guest>::{camel}>(arg0)
+      $($path_to_types)*::_export_drop_{snake}_cabi::<<$ty as $($path_to_types)*::Guest>::{camel}>(arg0)
     }}
 "#
                 );


### PR DESCRIPTION
After recent merge action, code generation appears to be broken in some ways. Here are some patches that made it work again, at least for my use case (symmetric ABI, regular asymmetric API)